### PR TITLE
chore: updating to 1.1.1 DEVOPS-1937

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push
 
 env:
-  CSI_PROXY_VERSION: 'v1.0.1'
+  CSI_PROXY_VERSION: 'v1.1.1'
 
 jobs:
   create_release:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # csi-proxy-builder
 
-For kubernets cluster to mount SMB shares in Windows nodes, it is required to be installed [csi-proxy](https://github.com/kubernetes-csi/csi-proxy) on windows host operating systems. Kubernetes SMB driver [csi-driver-smb](https://github.com/kubernetes-csi/csi-driver-smb#container-images--kubernetes-compatibility) depends on csi-proxy on windows nodes. 
+For a Kubernetes cluster to mount SMB shares in Windows nodes, it is required to be installed 
+[csi-proxy](https://github.com/kubernetes-csi/csi-proxy) on the Windows host operating systems. Kubernetes SMB driver 
+[csi-driver-smb](https://github.com/kubernetes-csi/csi-driver-smb#container-images--kubernetes-compatibility) depends on 
+csi-proxy on Windows nodes. 
 
 # Note this repo is public:
-Csi-proxy is an open source project, mostly maintained by Microsoft. To install csi-proxy on EC2 instances at boot time, publicly accessable downloand link is required. Currently csi-proxy developers do not distribute built binaries, see: https://github.com/kubernetes-csi/csi-proxy#build  This repository builds and publishes binaries as github release artifacts.
+Csi-proxy is an open source project, mostly maintained by Microsoft. To install csi-proxy on EC2 instances at boot time, 
+a publicly accessible download link is required. Currently, csi-proxy developers do not distribute built binaries, see: 
+https://github.com/kubernetes-csi/csi-proxy#build  This repository builds and publishes binaries as GitHub release 
+artifacts.


### PR DESCRIPTION
This doesn't fix the issues we're having, but is good to have the latest anyway.
Reminder: this is a public repo, so PRs are public too.  Keep any sensitive replies off the PR.